### PR TITLE
Create blender-booleans-and-flipped-normals

### DIFF
--- a/docs/asset-library-import/blender-booleans-and-flipped-normals
+++ b/docs/asset-library-import/blender-booleans-and-flipped-normals
@@ -1,0 +1,18 @@
+Here is the way I managed to get Booleans into Meta Horizon Worlds:
+ 
+1. **Apply all Modifiers**  
+   Make sure every Boolean (and other modifiers) is applied before export.
+ 
+2. **Join the Geometry**  
+   Select and join your meshes so they become one connected object.
+ 
+3. **Check the Normals**  
+   Verify that none of the Normals are flipped. Recalculate them if necessary.
+ 
+4. **Convert to Triangles**  
+   From the Faces of your mesh, create Triangles. This ensures the mesh displays correctly in Horizon.
+ 
+---
+ 
+👉 With this workflow I finally managed to bring my Boolean meshes into Horizon Worlds
+<iframe width="560" height="315" src="https://www.youtube.com/embed/VjZQY-y3hWo?si=pNLVIqUgN5ViiTK3" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>


### PR DESCRIPTION
docs: Add Blender Boolean import guide for Horizon Worlds Desktop Editor/ Asset Library

Added Markdown instructions with steps for applying modifiers, joining geometry, checking normals and triangulate faces to ensure correct import.